### PR TITLE
Initial release (binary install and simple config)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+.vagrant
+*~
+*#
+.#*
+\#*#
+.*.sw[a-z]
+*.un~
+
+# Bundler
+Gemfile.lock
+gems.locked
+bin/*
+.bundle/*
+
+# test kitchen
+.kitchen/
+.kitchen.local.yml
+
+# Chef
+Berksfile.lock
+.zero-knife.rb
+Policyfile.lock.json

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,23 @@
+---
+driver:
+  name: vagrant
+
+provisioner:
+  name: chef_zero
+
+verifier:
+  name: inspec
+
+platforms:
+  - name: ubuntu-18.04
+  - name: debian-9
+  - name: centos-7
+
+suites:
+  - name: default
+    run_list:
+      - recipe[mailhog::default]
+    verifier:
+      inspec_tests:
+        - test/integration/default
+    attributes:

--- a/Berksfile
+++ b/Berksfile
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+source 'https://supermarket.chef.io'
+
+metadata

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# mailhog changelog
+
+## 0.1.0
+
+* Initial release (binary install and simple config)

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
-MIT License
+The MIT License (MIT)
 
-Copyright (c) 2019 PAXFUL
+Copyright (c) 2019 Paxful
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -9,13 +9,13 @@ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,64 @@
-# chef-mailhog
-Chef cookbook for MailHog
+# Description
+
+## Overview
+
+This cookbook installs and configures [MailHog](https://github.com/mailhog/MailHog)
+
+### Tested on
+
+* Debian 9
+* Ubintu 18.04
+* Centos 7
+
+# Requirements
+
+
+## Chef Client:
+
+* chef (>= 14.0) ()
+
+## Platform:
+
+* ubuntu (>= 16.04)
+* debian (>= 9.0)
+* centos (>= 7.0)
+
+## Cookbooks:
+
+*No dependencies defined*
+
+# Attributes
+
+* `node['mailhog']['version']` -  Defaults to `v1.0.0`.
+* `node['mailhog']['install_path']` -  Defaults to `/usr/local/bin`.
+* `node['mailhog']['url_prefix']` -  Defaults to `nil`.
+* `node['mailhog']['http_port']` -  Defaults to `8025`.
+* `node['mailhog']['smtp_port']` -  Defaults to `587`.
+
+# Recipes
+
+* [mailhog::config](#mailhogconfig)
+* [mailhog::default](#mailhogdefault)
+* [mailhog::install](#mailhoginstall)
+
+## mailhog::config
+
+configure MailHog
+
+## mailhog::default
+
+main recipe
+
+## mailhog::install
+
+install MailHog
+
+# License and Maintainer
+
+Maintainer:: Paxful (<nikolay.antsiferov@paxful.com>)
+
+Source:: https://github.com/paxful/chef-mailhog
+
+Issues:: https://github.com/paxful/chef-mailhog/issues
+
+License:: MIT

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,0 +1,12 @@
+#
+# Cookbook:: mailhog
+# Attributes: default
+#
+
+default['mailhog']['version'] = 'v1.0.0'
+default['mailhog']['install_path'] = '/usr/local/bin'
+
+default['mailhog']['url_prefix'] = nil
+
+default['mailhog']['http_port'] = '8025'
+default['mailhog']['smtp_port'] = '587'

--- a/chefignore
+++ b/chefignore
@@ -1,0 +1,104 @@
+# Put files/directories that should be ignored in this file when uploading
+# to a chef-server or supermarket.
+# Lines that start with '# ' are comments.
+
+# OS generated files #
+######################
+.DS_Store
+Icon?
+nohup.out
+ehthumbs.db
+Thumbs.db
+
+# SASS #
+########
+.sass-cache
+
+# EDITORS #
+###########
+\#*
+.#*
+*~
+*.sw[a-z]
+*.bak
+REVISION
+TAGS*
+tmtags
+*_flymake.*
+*_flymake
+*.tmproj
+.project
+.settings
+mkmf.log
+
+## COMPILED ##
+##############
+a.out
+*.o
+*.pyc
+*.so
+*.com
+*.class
+*.dll
+*.exe
+*/rdoc/
+
+# Testing #
+###########
+.watchr
+.rspec
+spec/*
+spec/fixtures/*
+test/*
+features/*
+examples/*
+Guardfile
+Procfile
+.kitchen*
+kitchen.yml*
+.rubocop.yml
+spec/*
+Rakefile
+.travis.yml
+.foodcritic
+.codeclimate.yml
+
+# SCM #
+#######
+.git
+*/.git
+.gitignore
+.gitmodules
+.gitconfig
+.gitattributes
+.svn
+*/.bzr/*
+*/.hg/*
+*/.svn/*
+
+# Berkshelf #
+#############
+Berksfile
+Berksfile.lock
+cookbooks/*
+tmp
+
+# Bundler #
+###########
+vendor/*
+
+# Policyfile #
+##############
+Policyfile.rb
+Policyfile.lock.json
+
+# Cookbooks #
+#############
+CONTRIBUTING*
+CHANGELOG*
+TESTING*
+
+# Vagrant #
+###########
+.vagrant
+Vagrantfile

--- a/doc/overview.md
+++ b/doc/overview.md
@@ -1,0 +1,9 @@
+## Overview
+
+This cookbook installs and configures [MailHog](https://github.com/mailhog/MailHog)
+
+### Tested on
+
+* Debian 9
+* Ubintu 18.04
+* Centos 7

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,0 +1,15 @@
+name 'mailhog'
+maintainer 'Paxful'
+maintainer_email 'nikolay.antsiferov@paxful.com'
+license 'MIT'
+description 'Installs/Configures MailHog'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+source_url 'https://github.com/paxful/chef-mailhog'
+issues_url 'https://github.com/paxful/chef-mailhog/issues'
+version '0.1.0'
+
+chef_version '>= 14.0'
+
+supports 'ubuntu', '>= 16.04'
+supports 'debian', '>= 9.0'
+supports 'centos', '>= 7.0'

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -1,0 +1,47 @@
+#
+# Cookbook:: mailhog
+# Recipe:: config
+# <> configure MailHog
+#
+# The MIT License (MIT)
+#
+# Copyright:: 2019, Paxful
+#
+
+service_unit_content = {
+  'Unit' => {
+    'Description' => 'MailHog Service',
+    'After' => 'syslog.target',
+  },
+  'Service' => {
+    'EnvironmentFile' => '/etc/default/mailhog',
+    'ExecStart' => "#{node['mailhog']['install_path']}/mailhog",
+    'Restart' => 'on-failure',
+  },
+  'Install' => { 'WantedBy' => 'multi-user.target' },
+}
+
+systemd_unit 'mailhog.service' do
+  content service_unit_content
+  action :create
+  notifies(:restart, 'service[mailhog]')
+end
+
+template '/etc/default/mailhog' do
+  source 'env.erb'
+  owner 'root'
+  group 'root'
+  mode '0644'
+  variables(
+    hostname: node['fqdn'],
+    url_prefix: node['mailhog']['url_prefix'],
+    http_port: node['mailhog']['http_port'],
+    smtp_port: node['mailhog']['smtp_port']
+  )
+  notifies :restart, 'service[mailhog]'
+end
+
+# enable and start service
+service 'mailhog' do
+  action [ :enable, :start ]
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,0 +1,13 @@
+#
+# Cookbook:: mailhog
+# Recipe:: default
+# <> main recipe
+#
+# The MIT License (MIT)
+#
+# Copyright:: 2019, Paxful
+#
+
+# install & configure mailhog
+include_recipe 'mailhog::install'
+include_recipe 'mailhog::config'

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -1,0 +1,15 @@
+#
+# Cookbook:: mailhog
+# Recipe:: install
+# <> install MailHog
+#
+# The MIT License (MIT)
+#
+# Copyright:: 2019, Paxful
+#
+
+remote_file File.join(node['mailhog']['install_path'], 'mailhog') do
+  source "https://github.com/mailhog/MailHog/releases/download/#{node['mailhog']['version']}/MailHog_linux_amd64"
+  mode '0755'
+  show_progress true
+end

--- a/templates/env.erb
+++ b/templates/env.erb
@@ -1,0 +1,11 @@
+# This file is managed by Chef. Any modifications will be lost.
+
+MH_HOSTNAME=<%= @hostname %>
+
+<% if node['mailhog']['url_prefix'] %>
+MH_UI_WEB_PATH=<%= @url_prefix %>
+<% end %>
+
+MH_API_BIND_ADDR=0.0.0.0:<%= @http_port %>
+MH_UI_BIND_ADDR=0.0.0.0:<%= @http_port %>
+MH_SMTP_BIND_ADDR=0.0.0.0:<%= @smtp_port %>

--- a/test/integration/default/default_test.rb
+++ b/test/integration/default/default_test.rb
@@ -1,0 +1,16 @@
+# # encoding: utf-8
+
+# InSpec tests for mailhog
+
+describe service('mailhog') do
+  it { should be_enabled }
+  it { should be_running }
+end
+
+describe port(8025) do
+  it { should be_listening }
+end
+
+describe port(587) do
+  it { should be_listening }
+end


### PR DESCRIPTION
* Test kitchen for Ubuntu, Debian and Centos
* Install from binary
* Simple configuration for in-memory storage
* Autogenerated Readme with 'knife cookbook doc'